### PR TITLE
Add PAPI support; slight tweak on mines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ repositories {
 	maven { url 'https://nexus.hc.to/content/repositories/pub_releases' }
 	// IndividualSigns, NuVotifier
 	maven { url 'https://jitpack.io' }
+	maven { url = 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
 }
 
 dependencies {
@@ -51,6 +52,7 @@ dependencies {
 	compileOnly 'net.milkbowl.vault:VaultAPI:1.6'
 	compileOnly 'com.github.NuVotifier:NuVotifier:2.7.2'
 	compileOnly 'org.bstats:bstats-bukkit:3.0.0'
+	compileOnly 'me.clip:placeholderapi:2.11.2'
 
 	testImplementation 'org.bukkit:bukkit:1.14.2-R0.1-SNAPSHOT'
 	testImplementation 'junit:junit:4.13.1'

--- a/src/main/java/de/blablubbabc/paintball/Paintball.java
+++ b/src/main/java/de/blablubbabc/paintball/Paintball.java
@@ -35,6 +35,7 @@ import de.blablubbabc.paintball.gadgets.Gift;
 import de.blablubbabc.paintball.gadgets.WeaponManager;
 import de.blablubbabc.paintball.metrics.PluginMetrics;
 import de.blablubbabc.paintball.shop.ShopManager;
+import de.blablubbabc.paintball.thirdparty.PaintballPlaceholders;
 import de.blablubbabc.paintball.thirdparty.util.Updater;
 import de.blablubbabc.paintball.thirdparty.util.Updater.UpdateType;
 import de.blablubbabc.paintball.utils.Log;
@@ -1106,6 +1107,14 @@ public class Paintball extends JavaPlugin {
 			} else {
 				Log.info("Plugin 'Vault' not found. Additional vault-economy-reward features disabled.");
 			}
+		}
+		// PlaceholderAPI
+		Plugin papi = getServer().getPluginManager().getPlugin("PlaceholderAPI");
+		if (papi != null && papi.isEnabled()) {
+		    Log.info("Plugin 'PlaceholderAPI' found. Using it now.");
+		    new PaintballPlaceholders(this).register();
+		} else {
+		    Log.info("Plugin 'PlaceholderAPI' not found. Additional placeholder features disabled.");
 		}
 
 		// after all plugins are enabled:

--- a/src/main/java/de/blablubbabc/paintball/gadgets/handlers/MineHandler.java
+++ b/src/main/java/de/blablubbabc/paintball/gadgets/handlers/MineHandler.java
@@ -133,11 +133,11 @@ public class MineHandler extends WeaponHandler implements Listener {
 
 							@Override
 							public void run() {
-								block.setBlockData(Material.FLOWER_POT.createBlockData());
+								block.setBlockData(getItemType().createBlockData());
 							}
 						}, 1L);
 
-						plantMine(match, player, block, Material.FLOWER_POT, event.getBlockReplacedState(), this.getWeaponOrigin());
+						plantMine(match, player, block, getItemType(), event.getBlockReplacedState(), this.getWeaponOrigin());
 
 						if (itemInHand.getAmount() <= 1) {
 							playerInventory.setItemInMainHand(null);
@@ -399,7 +399,7 @@ public class MineHandler extends WeaponHandler implements Listener {
 						public void run() {
 							ball.dispose(true);
 						}
-					}, (long) Paintball.getInstance().mineTime);
+					}, Paintball.getInstance().mineTime);
 				}
 			}
 
@@ -422,7 +422,7 @@ public class MineHandler extends WeaponHandler implements Listener {
 
 		/**
 		 * Returns the creator of this mine.
-		 * 
+		 *
 		 * @return the creator of the mine
 		 */
 		public Player getOwner() {

--- a/src/main/java/de/blablubbabc/paintball/thirdparty/PaintballPlaceholders.java
+++ b/src/main/java/de/blablubbabc/paintball/thirdparty/PaintballPlaceholders.java
@@ -1,0 +1,91 @@
+package de.blablubbabc.paintball.thirdparty;
+
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+
+import de.blablubbabc.paintball.Lobby;
+import de.blablubbabc.paintball.Paintball;
+import de.blablubbabc.paintball.Rank;
+import de.blablubbabc.paintball.statistics.arena.ArenaStat;
+import de.blablubbabc.paintball.statistics.general.GeneralStat;
+import de.blablubbabc.paintball.statistics.player.PlayerStat;
+import de.blablubbabc.paintball.statistics.player.PlayerStats;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+
+public class PaintballPlaceholders extends PlaceholderExpansion {
+    private final Paintball pb;
+
+    public PaintballPlaceholders(Paintball pb) {
+        // Do not use class variables for managers, they are dropped when paintball reloads
+        this.pb = pb;
+    }
+
+    @Override
+    public String getAuthor() {
+        return pb.getDescription().getAuthors().get(0);
+    }
+
+    @Override
+    public String getIdentifier() {
+        return pb.getDescription().getName();
+    }
+
+    @Override
+    public String getVersion() {
+        // Extension version
+        return "1.0";
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String identifier) {
+        String[] generalArgs = identifier.split("_", 2);
+        if (generalArgs.length < 2) return null;
+
+        if (generalArgs[0].equalsIgnoreCase("general")) {
+            GeneralStat stat = GeneralStat.getFromKey(generalArgs[1]);
+            if (stat == null) return null;
+
+            return Integer.toString(pb.statsManager.getGerneralStats().get(stat));
+        } else if (generalArgs[0].equalsIgnoreCase("player")) {
+            PlayerStat stat = PlayerStat.getFromKey(generalArgs[1]);
+            if (stat == null) return null;
+
+            PlayerStats stats = pb.playerManager.getPlayerStats(player.getUniqueId());
+            if (stats == null) return null;
+
+            return Integer.toString(stats.getStat(stat));
+        } else if (generalArgs[0].equalsIgnoreCase("arena")) {
+            String[] arenaArgs = generalArgs[1].split(":", 2);
+            Map<ArenaStat,Integer> arenaStats = pb.arenaManager.getArenaStats(arenaArgs[0]);
+            if (arenaStats.size() == 0) return null;
+
+            ArenaStat stat = ArenaStat.getFromKey(arenaArgs[1]);
+            if (stat == null) return null;
+
+            return Integer.toString(arenaStats.get(stat));
+        } else if (generalArgs[0].equalsIgnoreCase("misc")) {
+
+            if (generalArgs[1].equalsIgnoreCase("rankprefix")) {
+                Rank rank = pb.rankManager.getRank(player.getUniqueId());
+                if (rank == null) return null;
+
+                return rank.getPrefix();
+            } else if (generalArgs[1].equalsIgnoreCase("chatcolor")) {
+                // Don't return null, because null doesn't replace the placeholder
+                if (!Lobby.LOBBY.isMember(player)) return "";
+
+                if (!Lobby.isPlaying(player) && !Lobby.isSpectating(player)) return "";
+
+                return pb.matchManager.getMatch(player).getTeamLobby(player).color().toString();
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/de/blablubbabc/paintball/thirdparty/PaintballPlaceholders.java
+++ b/src/main/java/de/blablubbabc/paintball/thirdparty/PaintballPlaceholders.java
@@ -17,7 +17,6 @@ public class PaintballPlaceholders extends PlaceholderExpansion {
     private final Paintball pb;
 
     public PaintballPlaceholders(Paintball pb) {
-        // Do not use class variables for managers, they are dropped when paintball reloads
         this.pb = pb;
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ description: '${pluginDescription}'
 
 main: de.blablubbabc.paintball.Paintball
 api-version: '1.14'
-softdepend: [InSigns, TagAPI, Votifier, Vault, Multiverse-Core, My Worlds, Transporter, Multiworld, PerWorldInventory]
+softdepend: [InSigns, TagAPI, Votifier, Vault, Multiverse-Core, My Worlds, Transporter, Multiworld, PerWorldInventory, PlaceholderAPI]
 
 commands:
     paintball:


### PR DESCRIPTION
This PR adds support for PlaceholderAPI and sets mines to use the material defined in the config.

I decided not to make a config option for the PlaceholderAPI extension because if you don't use it, it just doesn't do anything.

Available placeholders:
- Common:
  - `rounds`
  - `kills`
  - `shots`
  - `grenades`
  - `airstrikes`
- Arena stats: (`%paintball_arena_<arena_name>:<stat>%`)
  - all 'common' stats
- General stats: (`%paintball_general_<stat>%`)
  - all 'common' stats
  - `money_spent`
  - `average_players`
  - `max_players`
- Player stats: (`%paintball_player_<stat>`)
  - all 'common' stats
  - `money_spent`
  - `money`
  - `points`
  - `wins`
  - `defeats`
  - `draws`
  - `kd`
  - `deaths`
  - `hitquote`
  - `teamattacks`
  - `hits`

Examples:
- Get amount of shots fired in arena named "big_arena":
  - `%paintball_arena_big_arena:shots`
- Get total money spent:
  - `%paintball_general_money_spent%`
- Get player's number of wins (uses PAPI's player context):
  - `%paintball_player_wins%`

---

The adjustment to mines is so that you can change the mine material in the config. For example, my server uses pressure plates as mines with an additional tweak so that they explode immediately when stepped on.

Thanks!