### PR TITLE
Unregister PAPI hook; fix double-counted shots; clickable vote options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 	id 'maven-publish'
 }
 
-defaultTasks 'licenseFormat', 'clean', 'build', 'install'
+defaultTasks 'clean', 'build', 'publishToMavenLocal'
 
 eclipse {
 	project {

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ repositories {
 }
 
 dependencies {
-	compileOnly 'org.bukkit:bukkit:1.14.2-R0.1-SNAPSHOT'
+	compileOnly 'org.spigotmc:spigot-api:1.14.2-R0.1-SNAPSHOT'
 	compileOnly 'com.github.blablubbabc:IndividualSigns:2.7.0'
 	compileOnly 'net.milkbowl.vault:VaultAPI:1.6'
 	compileOnly 'com.github.NuVotifier:NuVotifier:2.7.2'

--- a/src/main/java/de/blablubbabc/paintball/Newsfeeder.java
+++ b/src/main/java/de/blablubbabc/paintball/Newsfeeder.java
@@ -12,9 +12,7 @@ import org.bukkit.entity.Player;
 
 import de.blablubbabc.paintball.utils.KeyValuePair;
 import de.blablubbabc.paintball.utils.Translator;
-import net.md_5.bungee.api.chat.ClickEvent;
-import net.md_5.bungee.api.chat.ClickEvent.Action;
-import net.md_5.bungee.api.chat.TextComponent;
+import de.blablubbabc.paintball.utils.spigot.SpigotUtils;
 
 public class Newsfeeder {
 	private Paintball plugin;
@@ -126,9 +124,7 @@ public class Newsfeeder {
 	
 	public void clickableText(CommandSender sender, String command, String message) {
 		String formatted = Translator.getString("TEXT", new KeyValuePair("plugin", pluginName), new KeyValuePair("message", message));
-		TextComponent component = new TextComponent(TextComponent.fromLegacyText(formatted));
-		component.setClickEvent(new ClickEvent(Action.RUN_COMMAND, command));
-		sender.spigot().sendMessage(component);
+		SpigotUtils.sendClickableText(sender, command, formatted);
 	}
 	
 	public void status(String message) {

--- a/src/main/java/de/blablubbabc/paintball/Newsfeeder.java
+++ b/src/main/java/de/blablubbabc/paintball/Newsfeeder.java
@@ -12,6 +12,9 @@ import org.bukkit.entity.Player;
 
 import de.blablubbabc.paintball.utils.KeyValuePair;
 import de.blablubbabc.paintball.utils.Translator;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ClickEvent.Action;
+import net.md_5.bungee.api.chat.TextComponent;
 
 public class Newsfeeder {
 	private Paintball plugin;
@@ -119,6 +122,13 @@ public class Newsfeeder {
 		} else {
 			sender.sendMessage(Translator.getString("TEXT", new KeyValuePair("plugin", pluginName), new KeyValuePair("message", message)));
 		}
+	}
+	
+	public void clickableText(CommandSender sender, String command, String message) {
+		String formatted = Translator.getString("TEXT", new KeyValuePair("plugin", pluginName), new KeyValuePair("message", message));
+		TextComponent component = new TextComponent(TextComponent.fromLegacyText(formatted));
+		component.setClickEvent(new ClickEvent(Action.RUN_COMMAND, command));
+		sender.spigot().sendMessage(component);
 	}
 	
 	public void status(String message) {

--- a/src/main/java/de/blablubbabc/paintball/Paintball.java
+++ b/src/main/java/de/blablubbabc/paintball/Paintball.java
@@ -104,6 +104,7 @@ public class Paintball extends JavaPlugin {
 	public InSignsFeature insignsFeature;
 
 	private VaultRewardsFeature vaultRewardsFeature;
+	private PaintballPlaceholders paintballPlaceholders;
 
 	public boolean active;
 	public boolean happyhour;
@@ -1112,7 +1113,8 @@ public class Paintball extends JavaPlugin {
 		Plugin papi = getServer().getPluginManager().getPlugin("PlaceholderAPI");
 		if (papi != null && papi.isEnabled()) {
 		    Log.info("Plugin 'PlaceholderAPI' found. Using it now.");
-		    new PaintballPlaceholders(this).register();
+		    paintballPlaceholders = new PaintballPlaceholders(this);
+		    paintballPlaceholders.register();
 		} else {
 		    Log.info("Plugin 'PlaceholderAPI' not found. Additional placeholder features disabled.");
 		}
@@ -1226,6 +1228,10 @@ public class Paintball extends JavaPlugin {
 		}
 
 		pluginMetrics.onDisable();
+
+		if (paintballPlaceholders != null) {
+		    paintballPlaceholders.unregister();
+		}
 
 		// wait for async tasks to complete:
 		final long start = System.currentTimeMillis();

--- a/src/main/java/de/blablubbabc/paintball/VoteManager.java
+++ b/src/main/java/de/blablubbabc/paintball/VoteManager.java
@@ -92,8 +92,8 @@ public class VoteManager {
 			votesPair.setValue(String.valueOf(option.getVotes()));
 			String arenaName = option.getArena();
 			
-			Paintball.getInstance().feeder.text(player, Translator.getString("GAME_VOTE_OPTION", idPair, votesPair, new KeyValuePair("arena", arenaName != null ? arenaName : randomOption)));
-			
+			String message = Translator.getString("GAME_VOTE_OPTION", idPair, votesPair, new KeyValuePair("arena", arenaName != null ? arenaName : randomOption));
+			Paintball.getInstance().feeder.clickableText(player, "/pb vote " + id, message);
 		}
 	}
 	

--- a/src/main/java/de/blablubbabc/paintball/gadgets/handlers/MarkerHandler.java
+++ b/src/main/java/de/blablubbabc/paintball/gadgets/handlers/MarkerHandler.java
@@ -85,10 +85,6 @@ public class MarkerHandler extends WeaponHandler {
 				Paintball.getInstance().weaponManager.getBallHandler().createBall(match, player, snowball, this.getWeaponOrigin());
 				// BOOST:
 				snowball.setVelocity(direction.multiply(Paintball.getInstance().speedmulti));
-				// STATS
-				// PLAYERSTATS
-				PlayerStats playerStats = Paintball.getInstance().playerManager.getPlayerStats(player.getUniqueId());
-				playerStats.addStat(PlayerStat.SHOTS, 1);
 				// INFORM MATCH
 				match.onShot(player);
 

--- a/src/main/java/de/blablubbabc/paintball/utils/spigot/SpigotUtils.java
+++ b/src/main/java/de/blablubbabc/paintball/utils/spigot/SpigotUtils.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) blablubbabc <http://www.blablubbabc.de>
+ * All rights reserved.
+ */
+package de.blablubbabc.paintball.utils.spigot;
+
+import org.bukkit.command.CommandSender;
+
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ClickEvent.Action;
+import net.md_5.bungee.api.chat.TextComponent;
+
+public final class SpigotUtils {
+
+	private SpigotUtils() {
+	}
+
+	// Null if not yet checked:
+	private static Boolean SPIGOT_AVAILABLE = null;
+
+	public static boolean isSpigotAvailable() {
+		// Check once and then cache the result:
+		if (SPIGOT_AVAILABLE == null) {
+			try {
+				Class.forName("org.bukkit.Server$Spigot");
+				SPIGOT_AVAILABLE = true;
+			} catch (ClassNotFoundException e) {
+				SPIGOT_AVAILABLE = false;
+			}
+		}
+		assert SPIGOT_AVAILABLE != null;
+		return SPIGOT_AVAILABLE;
+	}
+
+	public static void sendClickableText(CommandSender recipient, String command, String message) {
+		if (isSpigotAvailable()) {
+			Internal.sendClickableText(recipient, command, message);
+		} else {
+			// Fallback: Send non-clickable message.
+			recipient.sendMessage(message);
+		}
+	}
+
+	// A separate class that is only accessed if Spigot is present. Avoids class loading issues.
+	private static final class Internal {
+
+		private Internal() {
+		}
+
+		public static void sendClickableText(CommandSender recipient, String command, String message) {
+			TextComponent component = new TextComponent(TextComponent.fromLegacyText(message));
+			component.setClickEvent(new ClickEvent(Action.RUN_COMMAND, command));
+			recipient.spigot().sendMessage(component);
+		}
+	}
+}


### PR DESCRIPTION
This PR makes a couple changes:
- As noted in #1, the PlaceholderAPI expansion was not unregistered when the plugin is disabled. I tested and it didn't seem to cause any problems, (the newly registered hook replaces the old one in PAPI when reloading,) but I thought it was probably best to handle it properly anyway.
- Previously, when throwing paintballs (without using weapons) the player's "shots" stat would be incremented twice, so I removed one of the increment calls.
- The lines in the vote message are now clickable. To be able to do this, I set the plugin to depend on Spigot API instead of Bukkit, but I don't think there's any reason for people to be using CraftBukkit anymore, so I don't think this should be an issue. (The plugin may even run fine on CraftBukkit when the clickable text option is disabled, I'm not sure.)