### PR TITLE
Stack balls to 64

### DIFF
--- a/src/main/java/de/blablubbabc/paintball/gadgets/handlers/BallHandler.java
+++ b/src/main/java/de/blablubbabc/paintball/gadgets/handlers/BallHandler.java
@@ -78,6 +78,7 @@ public class BallHandler extends WeaponHandler {
 	protected ItemStack setItemMeta(ItemStack itemStack) {
 		ItemMeta meta = itemStack.getItemMeta();
 		meta.setDisplayName(Translator.getString("WEAPON_PAINTBALL"));
+		meta.setMaxStackSize(64);
 		itemStack.setItemMeta(meta);
 		return itemStack;
 	}

--- a/src/main/java/de/blablubbabc/paintball/gadgets/handlers/MarkerHandler.java
+++ b/src/main/java/de/blablubbabc/paintball/gadgets/handlers/MarkerHandler.java
@@ -53,6 +53,7 @@ public class MarkerHandler extends WeaponHandler {
 	protected ItemStack setItemMeta(ItemStack itemStack) {
 		ItemMeta meta = itemStack.getItemMeta();
 		meta.setDisplayName(Translator.getString("WEAPON_PAINTBALL"));
+		meta.setMaxStackSize(64);
 		itemStack.setItemMeta(meta);
 		return itemStack;
 	}


### PR DESCRIPTION
In recent versions snowballs were given to the player in stacks of 16 (at least on paper), what filled up much of the inventory. Additionally in older versions they were given as stacks of 64 but could only naturally stack to 16 so that caused issues when moving those snowballs around in the inventory. This change allows stacking them up to 64.
